### PR TITLE
[codex] Update website typography

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -14,14 +14,14 @@ const { title, description, pubDatetime, modDatetime, timezone, tags } = data;
 
 const headerProps = {
   style: { viewTransitionName: slugifyStr(title) },
-  class: "text-lg font-medium decoration-dashed hover:underline",
+  class: "text-lg font-normal decoration-dashed hover:underline",
 };
 ---
 
 <li class="my-6">
   <a
     href={getPath(id, filePath)}
-    class="inline-block text-lg font-medium text-accent decoration-dashed underline-offset-4 focus-visible:no-underline focus-visible:underline-offset-0"
+    class="inline-block text-xl font-medium text-accent decoration-dashed underline-offset-4 focus-visible:no-underline focus-visible:underline-offset-0"
   >
     {
       variant === "h2" ? (
@@ -35,12 +35,9 @@ const headerProps = {
   <p>{description}</p>
   {
     tags && tags.length > 0 && (
-      <div class="mt-1 flex flex-wrap gap-x-2 text-xs text-gray-500 dark:text-gray-400">
+      <div class="mt-1 flex flex-wrap gap-x-2 text-sm text-gray-500 dark:text-gray-400">
         {tags.map(tag => (
-          <a
-            href={`/tags/${slugifyStr(tag)}/`}
-            class="hover:text-accent"
-          >
+          <a href={`/tags/${slugifyStr(tag)}/`} class="hover:text-accent">
             #{tag}
           </a>
         ))}

--- a/src/components/Datetime.astro
+++ b/src/components/Datetime.astro
@@ -37,19 +37,19 @@ const date = datetime.format("D MMM, YYYY"); // e.g., '22 Mar, 2025'
 <div class:list={["flex items-center opacity-80", className]}>
   <IconCalendar
     class:list={[
-      "inline-block size-6 min-w-[1.375rem] -ml-1 mr-1",
+      "mr-1 -ml-1 inline-block size-6 min-w-[1.375rem]",
       { "scale-90": size === "sm" },
     ]}
   />
   {
     isModified && (
-      <span class:list={["text-sm", { "sm:text-base": size === "lg" }]}>
+      <span class:list={["text-base", { "sm:text-lg": size === "lg" }]}>
         Updated:
       </span>
     )
   }
   <time
-    class:list={["text-sm", { "sm:text-base": size === "lg" }]}
+    class:list={["text-base", { "sm:text-lg": size === "lg" }]}
     datetime={datetime.toISOString()}>{date}</time
   >
 </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -41,7 +41,7 @@ const isActive = (path: string) => {
     >
       <a
         href="/"
-        class="absolute py-1 text-xl leading-8 font-semibold whitespace-nowrap sm:static sm:my-auto sm:text-2xl sm:leading-none"
+        class="absolute py-1 font-serif text-xl leading-8 font-normal whitespace-nowrap sm:static sm:my-auto sm:text-2xl sm:leading-none"
       >
         {SITE.title}
       </a>

--- a/src/components/PhotoblogCard.astro
+++ b/src/components/PhotoblogCard.astro
@@ -17,14 +17,14 @@ const imageSrc = typeof ogImage === "string" ? ogImage : ogImage;
 
 <a
   href={postUrl}
-  class="group relative block aspect-square overflow-hidden bg-skin-card"
+  class="group bg-skin-card relative block aspect-square overflow-hidden"
 >
   {
     imageSrc && typeof imageSrc !== "string" ? (
       <Image
         src={imageSrc}
         alt={title}
-        class="h-full w-full object-cover aspect-square transition-transform duration-300 group-hover:scale-105"
+        class="aspect-square h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
         widths={[320, 640]}
         sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
       />
@@ -32,11 +32,11 @@ const imageSrc = typeof ogImage === "string" ? ogImage : ogImage;
       <img
         src={imageSrc}
         alt={title}
-        class="h-full w-full object-cover aspect-square transition-transform duration-300 group-hover:scale-105"
+        class="aspect-square h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
         loading="lazy"
       />
     ) : (
-      <div class="flex h-full w-full items-center justify-center bg-skin-card-muted">
+      <div class="bg-skin-card-muted flex h-full w-full items-center justify-center">
         <span class="text-skin-base opacity-50">No image</span>
       </div>
     )
@@ -45,7 +45,7 @@ const imageSrc = typeof ogImage === "string" ? ogImage : ogImage;
     class="absolute inset-0 flex items-end bg-gradient-to-t from-black/70 via-black/20 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100"
   >
     <h3
-      class="p-4 text-sm font-medium text-white"
+      class="p-4 text-sm font-normal text-white"
       style={{ viewTransitionName: slugifyStr(title) }}
     >
       {title}

--- a/src/components/Tag.astro
+++ b/src/components/Tag.astro
@@ -20,17 +20,17 @@ const { tag, tagName, size = "sm" } = Astro.props;
     href={`/tags/${tag}/`}
     transition:name={tag}
     class:list={[
-      "relative pe-2 text-lg underline decoration-dashed group-hover:-top-0.5 group-hover:text-accent focus-visible:p-1 focus-visible:no-underline",
-      { "text-sm": size === "sm" },
+      "relative inline-flex items-center gap-1 pe-2 text-xl underline decoration-dashed group-hover:-top-0.5 group-hover:text-accent focus-visible:p-1 focus-visible:no-underline",
+      { "text-base": size === "sm" },
     ]}
   >
     <IconHash
       class:list={[
-        "inline-block opacity-80",
-        { "-me-3.5 size-4": size === "sm" },
-        { "-me-5 size-6": size === "lg" },
+        "inline-block shrink-0 opacity-80",
+        { "size-4": size === "sm" },
+        { "size-6": size === "lg" },
       ]}
     />
-    &nbsp;<span>{tagName}</span>
+    <span>{tagName}</span>
   </a>
 </li>

--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -28,14 +28,14 @@ const backUrl = SITE.showBackButton ? Astro.url.pathname : "/";
 >
   {
     "titleTransition" in props ? (
-      <h1 class="text-2xl font-semibold sm:text-3xl">
+      <h1 class="text-2xl font-normal sm:text-3xl">
         {props.pageTitle[0]}
         <span transition:name={props.titleTransition}>
           {props.pageTitle[1]}
         </span>
       </h1>
     ) : (
-      <h1 class="text-2xl font-semibold sm:text-3xl">{props.pageTitle}</h1>
+      <h1 class="text-2xl font-normal sm:text-3xl">{props.pageTitle}</h1>
     )
   }
   <p class="mt-2 mb-6 italic">{props.pageDesc}</p>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -95,7 +95,7 @@ const nextPost =
   >
     <h1
       transition:name={slugifyStr(title)}
-      class="inline-block text-2xl font-bold text-accent sm:text-3xl"
+      class="inline-block text-2xl font-normal text-accent sm:text-3xl"
     >
       {title}
     </h1>
@@ -145,7 +145,7 @@ const nextPost =
             <IconChevronLeft class="inline-block flex-none rtl:rotate-180" />
             <div>
               <span>Previous Post</span>
-              <div class="text-sm text-accent/85">{prevPost.title}</div>
+              <div class="text-base text-accent/85">{prevPost.title}</div>
             </div>
           </a>
         )
@@ -158,7 +158,7 @@ const nextPost =
           >
             <div>
               <span>Next Post</span>
-              <div class="text-sm text-accent/85">{nextPost.title}</div>
+              <div class="text-base text-accent/85">{nextPost.title}</div>
             </div>
             <IconChevronRight class="inline-block flex-none rtl:rotate-180" />
           </a>

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -43,8 +43,8 @@ const months = [
         .sort(([yearA], [yearB]) => Number(yearB) - Number(yearA))
         .map(([year, yearGroup]) => (
           <div>
-            <span class="text-2xl font-bold">{year}</span>
-            <sup class="text-sm">{yearGroup.length}</sup>
+            <span class="text-3xl font-bold">{year}</span>
+            <sup class="text-base">{yearGroup.length}</sup>
             {Object.entries(
               getPostsByGroupCondition(
                 yearGroup,
@@ -54,9 +54,9 @@ const months = [
               .sort(([monthA], [monthB]) => Number(monthB) - Number(monthA))
               .map(([month, monthGroup]) => (
                 <div class="flex flex-col sm:flex-row">
-                  <div class="mt-6 min-w-36 text-lg sm:my-6">
+                  <div class="mt-6 min-w-36 text-xl sm:my-6">
                     <span class="font-bold">{months[Number(month) - 1]}</span>
-                    <sup class="text-xs">{monthGroup.length}</sup>
+                    <sup class="text-sm">{monthGroup.length}</sup>
                   </div>
                   <ul>
                     {monthGroup

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,7 +30,8 @@ const photoblogPosts = sortedPosts.filter(({ data }) =>
   <main id="main-content" data-layout="index">
     <section id="hero" class="pt-8 pb-6">
       <p class="[&_a]:inline-link">
-        Willkommen auf meinem Blog. Hier teile ich Fotos und Zeichnungen aus Wien, von Reisen und aus dem Alltag.
+        Willkommen auf meinem Blog. Hier teile ich Fotos und Zeichnungen aus
+        Wien, von Reisen und aus dem Alltag.
       </p>
       {
         // only display if at least one social link is enabled
@@ -49,7 +50,7 @@ const photoblogPosts = sortedPosts.filter(({ data }) =>
       featuredPosts.length > 0 && (
         <>
           <section id="featured" class="pt-12 pb-6">
-            <h2 class="text-2xl font-semibold tracking-wide">Featured</h2>
+            <h2 class="text-2xl font-normal tracking-wide">Featured</h2>
             <ul>
               {featuredPosts.map(data => (
                 <Card variant="h3" {...data} />
@@ -65,8 +66,10 @@ const photoblogPosts = sortedPosts.filter(({ data }) =>
       photoblogPosts.length > 0 && (
         <>
           <section id="photoblog" class="pt-12 pb-6">
-            <h2 class="mb-6 text-2xl font-semibold tracking-wide">Photoblog</h2>
-            <PhotoblogGrid posts={photoblogPosts.slice(0, SITE.photoblogPostsPerIndex)} />
+            <h2 class="mb-6 text-2xl font-normal tracking-wide">Photoblog</h2>
+            <PhotoblogGrid
+              posts={photoblogPosts.slice(0, SITE.photoblogPostsPerIndex)}
+            />
             <div class="my-8 text-center">
               <LinkButton href="/tags/fotoblog/">
                 All Photos
@@ -82,7 +85,7 @@ const photoblogPosts = sortedPosts.filter(({ data }) =>
     {
       recentPosts.length > 0 && (
         <section id="recent-posts" class="pt-12 pb-6">
-          <h2 class="text-2xl font-semibold tracking-wide">Previous Posts</h2>
+          <h2 class="text-2xl font-normal tracking-wide">Previous Posts</h2>
           <ul>
             {recentPosts.map(
               (data, index) =>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -91,7 +91,7 @@ const backUrl = SITE.showBackButton ? `${Astro.url.pathname}` : "/";
 
 <style is:global>
   #pagefind-search {
-    --pagefind-ui-font: var(--font-mono);
+    --pagefind-ui-font: var(--font-sans);
     --pagefind-ui-text: var(--foreground);
     --pagefind-ui-background: var(--background);
     --pagefind-ui-border: var(--border);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,700;1,400;1,700&family=Literata:opsz,wght@7..72,400..700&display=swap");
 @import "tailwindcss";
 @import "./typography.css";
 
@@ -26,6 +27,8 @@ html[data-theme="dark"] {
   --color-accent: var(--accent);
   --color-muted: var(--muted);
   --color-border: var(--border);
+  --font-sans: "Cormorant Garamond", Georgia, serif;
+  --font-serif: "Literata", Georgia, serif;
 }
 
 @layer base {
@@ -38,7 +41,15 @@ html[data-theme="dark"] {
     @apply overflow-y-scroll scroll-smooth;
   }
   body {
-    @apply flex min-h-svh flex-col bg-background font-mono text-foreground selection:bg-accent/75 selection:text-background;
+    @apply flex min-h-svh flex-col bg-background font-sans text-xl leading-relaxed text-foreground selection:bg-accent/75 selection:text-background;
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-serif font-normal;
   }
   a,
   button {

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -3,7 +3,7 @@
 @layer base {
   /* ===== Override default Tailwind Typography styles ===== */
   .app-prose {
-    @apply prose;
+    @apply prose prose-lg;
 
     h1,
     h2,
@@ -13,8 +13,27 @@
       @apply mb-3 text-foreground;
     }
 
+    h1,
+    h2,
+    h3,
+    h4 {
+      @apply font-normal;
+    }
+
+    h1 {
+      @apply text-4xl;
+    }
+
+    h2 {
+      @apply text-2xl;
+    }
+
     h3 {
-      @apply italic;
+      @apply text-xl;
+    }
+
+    h4 {
+      @apply text-lg;
     }
 
     p,

--- a/src/utils/loadGoogleFont.ts
+++ b/src/utils/loadGoogleFont.ts
@@ -1,9 +1,14 @@
 async function loadGoogleFont(
   font: string,
   text: string,
-  weight: number
+  weight: number,
+  style: string
 ): Promise<ArrayBuffer> {
-  const API = `https://fonts.googleapis.com/css2?family=${font}:wght@${weight}&text=${encodeURIComponent(text)}`;
+  const family =
+    style === "italic"
+      ? `${font}:ital,wght@1,${weight}`
+      : `${font}:wght@${weight}`;
+  const API = `https://fonts.googleapis.com/css2?family=${family}&text=${encodeURIComponent(text)}`;
 
   const css = await (
     await fetch(API, {
@@ -15,7 +20,7 @@ async function loadGoogleFont(
   ).text();
 
   const resource = css.match(
-    /src: url\((.+?)\) format\('(opentype|truetype)'\)/
+    /src: url\((.+?)\) format\('(opentype|truetype|woff2)'\)/
   );
 
   if (!resource) throw new Error("Failed to download dynamic font");
@@ -36,22 +41,46 @@ async function loadGoogleFonts(
 > {
   const fontsConfig = [
     {
-      name: "IBM Plex Mono",
-      font: "IBM+Plex+Mono",
+      name: "Cormorant Garamond",
+      font: "Cormorant+Garamond",
       weight: 400,
       style: "normal",
     },
     {
-      name: "IBM Plex Mono",
-      font: "IBM+Plex+Mono",
+      name: "Cormorant Garamond",
+      font: "Cormorant+Garamond",
       weight: 700,
-      style: "bold",
+      style: "normal",
+    },
+    {
+      name: "Cormorant Garamond",
+      font: "Cormorant+Garamond",
+      weight: 400,
+      style: "italic",
+    },
+    {
+      name: "Cormorant Garamond",
+      font: "Cormorant+Garamond",
+      weight: 700,
+      style: "italic",
+    },
+    {
+      name: "Literata",
+      font: "Literata",
+      weight: 400,
+      style: "normal",
+    },
+    {
+      name: "Literata",
+      font: "Literata",
+      weight: 700,
+      style: "normal",
     },
   ];
 
   const fonts = await Promise.all(
     fontsConfig.map(async ({ name, font, weight, style }) => {
-      const data = await loadGoogleFont(font, text, weight);
+      const data = await loadGoogleFont(font, text, weight, style);
       return { name, data, weight, style };
     })
   );

--- a/src/utils/og-templates/post.js
+++ b/src/utils/og-templates/post.js
@@ -155,8 +155,9 @@ export default async post => {
                       type: "p",
                       props: {
                         style: {
+                          fontFamily: "Literata",
                           fontSize: 72,
-                          fontWeight: "bold",
+                          fontWeight: 400,
                           maxHeight: "84%",
                           overflow: "hidden",
                         },
@@ -167,6 +168,7 @@ export default async post => {
                       type: "div",
                       props: {
                         style: {
+                          fontFamily: "Cormorant Garamond",
                           display: "flex",
                           justifyContent: "space-between",
                           width: "100%",

--- a/src/utils/og-templates/site.js
+++ b/src/utils/og-templates/site.js
@@ -64,6 +64,7 @@ export default async () => {
                       type: "div",
                       props: {
                         style: {
+                          fontFamily: "Cormorant Garamond",
                           display: "flex",
                           flexDirection: "column",
                           justifyContent: "center",
@@ -77,7 +78,11 @@ export default async () => {
                           {
                             type: "p",
                             props: {
-                              style: { fontSize: 72, fontWeight: "bold" },
+                              style: {
+                                fontFamily: "Literata",
+                                fontSize: 72,
+                                fontWeight: 400,
+                              },
                               children: SITE.title,
                             },
                           },
@@ -95,6 +100,7 @@ export default async () => {
                       type: "div",
                       props: {
                         style: {
+                          fontFamily: "Cormorant Garamond",
                           display: "flex",
                           justifyContent: "flex-end",
                           width: "100%",


### PR DESCRIPTION
## Summary

Implements the typography update from issue #8 and the follow-up visual refinements discussed while previewing the site.

## Changes

- Added Google Font loading for `Literata` and `Cormorant Garamond`.
- Uses `Literata` for headings, page titles, post titles, card headings, and the site title in the header.
- Uses `Cormorant Garamond` for body/UI text and keeps its larger text scale.
- Loads real `Cormorant Garamond` italic variants so italic text uses the designed italic font instead of browser-synthesized italics.
- Updated Tailwind v4 font tokens and global base typography rules.
- Updated post prose heading styles so headings are regular weight and non-italic.
- Fixed tag hashtag spacing/alignment so the hash icon no longer overlaps the tag text.
- Updated Pagefind search font usage to follow the site text font.
- Updated generated OG image font loading and templates to use the new heading/body font pairing.

## Validation

- `npm run build`
- Targeted Prettier checks on touched files

## Notes

Only typography-related files were committed. Existing unstaged blog/image content changes in the worktree were intentionally left out of this PR.

Closes #8 