### PR TITLE
[codex] Add editorial post list layout

### DIFF
--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -6,10 +6,14 @@ const currentUrlPath = Astro.url.pathname.replace(/\/+$/, "");
 // eg: /tags/tailwindcss => ['tags', 'tailwindcss']
 const breadcrumbList = currentUrlPath.split("/").slice(1);
 
-// if breadcrumb is Home > Posts > 1 <etc>
-// replace Posts with Posts (page number)
-if (breadcrumbList[0] === "posts") {
-  breadcrumbList.splice(0, 2, `Posts (page ${breadcrumbList[1] || 1})`);
+// Keep the first posts page as Home > Posts. For paginated list pages,
+// only show a page number when the URL actually contains one.
+if (breadcrumbList[0] === "posts" && !breadcrumbList[1]) {
+  breadcrumbList.splice(0, 1, "Posts");
+}
+
+if (breadcrumbList[0] === "posts" && !isNaN(Number(breadcrumbList[1]))) {
+  breadcrumbList.splice(0, 2, `Posts (page ${breadcrumbList[1]})`);
 }
 
 // if breadcrumb is Home > Tags > [tag] > [page] <etc>

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -3,6 +3,7 @@ import { slugifyStr } from "@/utils/slugify";
 import type { CollectionEntry } from "astro:content";
 import { getPath } from "@/utils/getPath";
 import Datetime from "./Datetime.astro";
+import { Image } from "astro:assets";
 
 export interface Props extends CollectionEntry<"blog"> {
   variant?: "h2" | "h3";
@@ -10,32 +11,91 @@ export interface Props extends CollectionEntry<"blog"> {
 
 const { variant = "h2", data, id, filePath } = Astro.props;
 
-const { title, description, pubDatetime, modDatetime, timezone, tags } = data;
+const {
+  title,
+  description,
+  pubDatetime,
+  modDatetime,
+  timezone,
+  tags,
+  thumbnail,
+  heroImage,
+  ogImage,
+} = data;
+
+const postUrl = getPath(id, filePath);
+const image = thumbnail ?? heroImage ?? ogImage;
 
 const headerProps = {
   style: { viewTransitionName: slugifyStr(title) },
-  class: "text-lg font-normal decoration-dashed hover:underline",
+  class:
+    "text-2xl font-normal leading-snug decoration-dashed underline-offset-4 group-hover:underline",
 };
 ---
 
-<li class="my-6">
-  <a
-    href={getPath(id, filePath)}
-    class="inline-block text-xl font-medium text-accent decoration-dashed underline-offset-4 focus-visible:no-underline focus-visible:underline-offset-0"
-  >
+<li class="border-b border-border/70 py-8 first:pt-0 last:border-b-0">
+  <article class="group grid gap-5 sm:grid-cols-[minmax(0,1fr)_10rem] sm:gap-8">
+    <div class="min-w-0">
+      <Datetime
+        {pubDatetime}
+        {modDatetime}
+        {timezone}
+        class="mb-2 text-text-subtle"
+      />
+      <a
+        href={postUrl}
+        class="inline-block text-foreground focus-visible:no-underline focus-visible:underline-offset-0"
+      >
+        {
+          variant === "h2" ? (
+            <h2 {...headerProps}>{title}</h2>
+          ) : (
+            <h3 {...headerProps}>{title}</h3>
+          )
+        }
+      </a>
+      {
+        description && (
+          <p class="mt-3 leading-relaxed text-foreground/85">{description}</p>
+        )
+      }
+    </div>
     {
-      variant === "h2" ? (
-        <h2 {...headerProps}>{title}</h2>
-      ) : (
-        <h3 {...headerProps}>{title}</h3>
-      )
+      image && typeof image !== "string" ? (
+        <a
+          href={postUrl}
+          class="post-card-thumbnail relative block aspect-[4/3] overflow-hidden bg-muted sm:mt-8"
+          aria-label={title}
+        >
+          <Image
+            src={image}
+            alt={title}
+            class="absolute inset-0 h-full w-full object-cover object-center transition-transform duration-300 group-hover:scale-105"
+            style={{ objectPosition: "50% 50%" }}
+            widths={[240, 480, 720]}
+            sizes="(max-width: 640px) 100vw, 10rem"
+          />
+        </a>
+      ) : image ? (
+        <a
+          href={postUrl}
+          class="post-card-thumbnail relative block aspect-[4/3] overflow-hidden bg-muted sm:mt-8"
+          aria-label={title}
+        >
+          <img
+            src={image}
+            alt={title}
+            class="absolute inset-0 h-full w-full object-cover object-center transition-transform duration-300 group-hover:scale-105"
+            style={{ objectPosition: "50% 50%" }}
+            loading="lazy"
+          />
+        </a>
+      ) : null
     }
-  </a>
-  <Datetime {pubDatetime} {modDatetime} {timezone} />
-  <p>{description}</p>
+  </article>
   {
     tags && tags.length > 0 && (
-      <div class="mt-1 flex flex-wrap gap-x-2 text-sm text-gray-500 dark:text-gray-400">
+      <div class="mt-4 flex flex-wrap gap-x-2 text-sm text-foreground/60">
         {tags.map(tag => (
           <a href={`/tags/${slugifyStr(tag)}/`} class="hover:text-accent">
             #{tag}
@@ -45,3 +105,12 @@ const headerProps = {
     )
   }
 </li>
+
+<style>
+  .post-card-thumbnail :global(img) {
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+    object-position: center;
+  }
+</style>

--- a/src/components/Datetime.astro
+++ b/src/components/Datetime.astro
@@ -2,7 +2,6 @@
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
-import IconCalendar from "@/assets/icons/IconCalendar.svg";
 import { SITE } from "@/config";
 
 dayjs.extend(utc);
@@ -35,21 +34,15 @@ const date = datetime.format("D MMM, YYYY"); // e.g., '22 Mar, 2025'
 ---
 
 <div class:list={["flex items-center opacity-80", className]}>
-  <IconCalendar
-    class:list={[
-      "mr-1 -ml-1 inline-block size-6 min-w-[1.375rem]",
-      { "scale-90": size === "sm" },
-    ]}
-  />
   {
     isModified && (
-      <span class:list={["text-base", { "sm:text-lg": size === "lg" }]}>
+      <span class:list={["text-lg", { "sm:text-xl": size === "lg" }]}>
         Updated:
       </span>
     )
   }
   <time
-    class:list={["text-base", { "sm:text-lg": size === "lg" }]}
+    class:list={["text-lg", { "sm:text-xl": size === "lg" }]}
     datetime={datetime.toISOString()}>{date}</time
   >
 </div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -15,6 +15,7 @@ const blog = defineCollection({
       featured: z.boolean().optional(),
       draft: z.boolean().optional(),
       tags: z.array(z.string()).default(["others"]),
+      thumbnail: image().or(z.string()).optional(),
       ogImage: image().or(z.string()).optional(),
       heroImage: image().or(z.string()).optional(),
       heroImageAlt: z.string().optional(),

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -123,7 +123,7 @@ const nextPost =
     }
     <time
       datetime={pubDatetime.toISOString()}
-      class="mb-2 block text-base text-text-subtle"
+      class="mb-2 block text-lg text-text-subtle"
     >
       {postDate}
     </time>
@@ -136,7 +136,11 @@ const nextPost =
     <ul class="">
       {tags.map(tag => <Tag tag={slugifyStr(tag)} tagName={tag} />)}
     </ul>
-    {SITE.editPost.enabled && <EditPost {hideEditPost} {post} class="mt-2 max-sm:hidden" />}
+    {
+      SITE.editPost.enabled && (
+        <EditPost {hideEditPost} {post} class="mt-2 max-sm:hidden" />
+      )
+    }
     <article
       id="article"
       class="app-prose mx-auto mt-8 max-w-app prose-pre:bg-(--shiki-light-bg) dark:prose-pre:bg-(--shiki-dark-bg)"

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -58,7 +58,7 @@ const months = [
                     <span class="font-bold">{months[Number(month) - 1]}</span>
                     <sup class="text-sm">{monthGroup.length}</sup>
                   </div>
-                  <ul>
+                  <ul class="min-w-0 flex-1">
                     {monthGroup
                       .sort(
                         (a, b) =>


### PR DESCRIPTION
## Summary

Adds the editorial list layout for regular post previews from issue #15.

## Changes

- Restyles regular post cards with date-first editorial spacing, optional right-side thumbnails, and softer metadata.
- Adds optional thumbnail frontmatter support with fallback to heroImage and ogImage.
- Keeps thumbnails consistently center-cropped and aligns archive thumbnails across month groups.
- Removes the first-page breadcrumb label so /posts/ shows Home » Posts.

## Validation

- npm run build

Closes #15