### PR TITLE
[codex] Polish post metadata and German dates

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -29,19 +29,14 @@ const image = thumbnail ?? heroImage ?? ogImage;
 const headerProps = {
   style: { viewTransitionName: slugifyStr(title) },
   class:
-    "text-2xl font-normal leading-snug decoration-dashed underline-offset-4 group-hover:underline",
+    "text-[1.45rem] font-normal leading-snug decoration-dashed underline-offset-4 group-hover:underline sm:text-2xl",
 };
 ---
 
 <li class="border-b border-border/70 py-8 first:pt-0 last:border-b-0">
   <article class="group grid gap-5 sm:grid-cols-[minmax(0,1fr)_10rem] sm:gap-8">
     <div class="min-w-0">
-      <Datetime
-        {pubDatetime}
-        {modDatetime}
-        {timezone}
-        class="mb-2 text-text-subtle"
-      />
+      <Datetime {pubDatetime} {modDatetime} {timezone} class="mb-2" />
       <a
         href={postUrl}
         class="inline-block text-foreground focus-visible:no-underline focus-visible:underline-offset-0"

--- a/src/components/Datetime.astro
+++ b/src/components/Datetime.astro
@@ -1,11 +1,5 @@
 ---
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
-import timezone from "dayjs/plugin/timezone";
-import { SITE } from "@/config";
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
+import { formatGermanDate } from "@/utils/formatDate";
 
 export interface Props {
   class?: string;
@@ -24,25 +18,32 @@ const {
 } = Astro.props;
 
 /* ========== Formatted Datetime ========== */
-const isModified = modDatetime && modDatetime > pubDatetime;
+const pubDate = new Date(pubDatetime);
+const modDate = modDatetime ? new Date(modDatetime) : null;
+const isModified = modDate && modDate.getTime() > pubDate.getTime();
+const datetime = isModified ? modDate : pubDate;
 
-const datetime = dayjs(isModified ? modDatetime : pubDatetime).tz(
-  postTimezone || SITE.timezone
-);
-
-const date = datetime.format("D MMM, YYYY"); // e.g., '22 Mar, 2025'
+const date = formatGermanDate(datetime, postTimezone);
 ---
 
-<div class:list={["flex items-center opacity-80", className]}>
+<div class:list={["flex items-center gap-1", className]}>
   {
     isModified && (
-      <span class:list={["text-lg", { "sm:text-xl": size === "lg" }]}>
-        Updated:
+      <span
+        class:list={[
+          "font-sans text-base tracking-wide text-text-subtle italic",
+          { "sm:text-lg": size === "lg" },
+        ]}
+      >
+        Aktualisiert:
       </span>
     )
   }
   <time
-    class:list={["text-lg", { "sm:text-xl": size === "lg" }]}
+    class:list={[
+      "font-sans text-base tracking-wide text-text-subtle italic",
+      { "sm:text-lg": size === "lg" },
+    ]}
     datetime={datetime.toISOString()}>{date}</time
   >
 </div>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -10,6 +10,7 @@ import ShareLinks from "@/components/ShareLinks.astro";
 import BackButton from "@/components/BackButton.astro";
 import BackToTopButton from "@/components/BackToTopButton.astro";
 import { getPath } from "@/utils/getPath";
+import { formatGermanDate } from "@/utils/formatDate";
 import { slugifyStr } from "@/utils/slugify";
 import IconChevronLeft from "@/assets/icons/IconChevronLeft.svg";
 import IconChevronRight from "@/assets/icons/IconChevronRight.svg";
@@ -39,12 +40,7 @@ const {
 
 const { Content } = await render(post);
 
-const postDate = new Intl.DateTimeFormat("de-AT", {
-  day: "numeric",
-  month: "long",
-  year: "numeric",
-  timeZone: timezone || SITE.timezone,
-}).format(pubDatetime);
+const postDate = formatGermanDate(pubDatetime, timezone);
 
 let ogImageUrl: string | undefined;
 
@@ -123,7 +119,7 @@ const nextPost =
     }
     <time
       datetime={pubDatetime.toISOString()}
-      class="mb-2 block text-lg text-text-subtle"
+      class="mb-2 block font-sans text-xl tracking-wide text-text-subtle italic"
     >
       {postDate}
     </time>

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -6,6 +6,7 @@ import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
 import Card from "@/components/Card.astro";
 import getPostsByGroupCondition from "@/utils/getPostsByGroupCondition";
+import { formatGermanMonth } from "@/utils/formatDate";
 import { SITE } from "@/config";
 
 // Redirect to 404 page if `showArchives` config is false
@@ -14,21 +15,6 @@ if (!SITE.showArchives) {
 }
 
 const posts = await getCollection("blog", ({ data }) => !data.draft);
-
-const months = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December",
-];
 ---
 
 <Layout title={`Archives | ${SITE.title}`}>
@@ -55,7 +41,9 @@ const months = [
               .map(([month, monthGroup]) => (
                 <div class="flex flex-col sm:flex-row">
                   <div class="mt-6 min-w-36 text-xl sm:my-6">
-                    <span class="font-bold">{months[Number(month) - 1]}</span>
+                    <span class="font-bold">
+                      {formatGermanMonth(Number(month))}
+                    </span>
                     <sup class="text-sm">{monthGroup.length}</sup>
                   </div>
                   <ul class="min-w-0 flex-1">

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,22 @@
+import { SITE } from "@/config";
+
+const DATE_LOCALE = "de-AT";
+
+export function formatGermanDate(
+  date: string | Date,
+  timezone: string | undefined = SITE.timezone
+) {
+  return new Intl.DateTimeFormat(DATE_LOCALE, {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: timezone,
+  }).format(new Date(date));
+}
+
+export function formatGermanMonth(month: number) {
+  return new Intl.DateTimeFormat(DATE_LOCALE, {
+    month: "long",
+    timeZone: "UTC",
+  }).format(new Date(Date.UTC(2020, month - 1, 1)));
+}


### PR DESCRIPTION
## Summary

- Format visible post dates consistently in German long form across post lists, archives, and post detail pages.
- Use the site Cormorant Garamond italic face for editorial date metadata.
- Keep tags in their existing visual style while making compact post headings slightly less dominant.

## Validation

- npx prettier --check src/layouts/PostDetails.astro
- npm run build

Closes #17