### PR TITLE
[codex] Style post blockquotes

### DIFF
--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -101,6 +101,25 @@
       @apply border-s-accent/80 break-words opacity-80;
     }
 
+    &#article blockquote {
+      @apply relative my-8 border-0 bg-transparent py-1 ps-8 pe-0 font-normal not-italic text-foreground opacity-100 shadow-none;
+      quotes: none;
+    }
+
+    &#article blockquote::before {
+      content: "\201c";
+      @apply absolute top-0 start-0 font-serif text-4xl leading-none font-bold not-italic text-accent-highlight;
+    }
+
+    &#article blockquote::after {
+      content: "";
+      @apply absolute start-2 top-10 bottom-1 w-px bg-accent-highlight;
+    }
+
+    &#article blockquote p {
+      @apply my-0 font-normal not-italic text-foreground before:content-none after:content-none;
+    }
+
     details {
       @apply inline-block cursor-pointer text-foreground select-none [&_p]:hidden [&_ul]:!my-0;
     }


### PR DESCRIPTION
## Summary

Updates blog post blockquotes to match the requested visual treatment:

- removes the quote card/background treatment
- keeps the decorative quote mark upright and non-italic
- positions the accent line underneath the quote mark
- scopes the styling to post content only

## Validation

- npm run build