### PR TITLE
[codex] Rename fotografie tag

### DIFF
--- a/src/data/blog/2024/06/28/geburtstagsgeschenk-fuer-papa.mdx
+++ b/src/data/blog/2024/06/28/geburtstagsgeschenk-fuer-papa.mdx
@@ -6,7 +6,7 @@ draft: true
 tags:
   - zeichnen
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/geburtstagsgeschenk-fuer-papa/cover.jpg"
 ---
 

--- a/src/data/blog/2024/10/20/hagebutte.mdx
+++ b/src/data/blog/2024/10/20/hagebutte.mdx
@@ -6,7 +6,7 @@ draft: true
 tags:
   - fotos
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/hagebutte/cover.jpg"
 ---
 

--- a/src/data/blog/2024/10/20/sonnenuntergang-im-weingarten.mdx
+++ b/src/data/blog/2024/10/20/sonnenuntergang-im-weingarten.mdx
@@ -6,7 +6,7 @@ draft: true
 tags:
   - sonnenuntergang
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/sonnenuntergang-im-weingarten/cover.jpg"
 ---
 

--- a/src/data/blog/2024/10/29/la-vie-en-rose.mdx
+++ b/src/data/blog/2024/10/29/la-vie-en-rose.mdx
@@ -7,7 +7,7 @@ tags:
   - natur
   - musik
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/la-vie-en-rose/cover.jpg"
 ---
 

--- a/src/data/blog/2024/10/29/ringelspiel.mdx
+++ b/src/data/blog/2024/10/29/ringelspiel.mdx
@@ -6,7 +6,7 @@ tags:
   - blumen
   - natur
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "src/assets/blogimages/ringelspiel/cover.jpg"
 ---
 

--- a/src/data/blog/2024/12/24/lucky.mdx
+++ b/src/data/blog/2024/12/24/lucky.mdx
@@ -5,7 +5,7 @@ description: ""
 draft: true
 tags:
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/lucky/cover.jpg"
 ---
 

--- a/src/data/blog/2024/12/24/weihnachtsbaum.mdx
+++ b/src/data/blog/2024/12/24/weihnachtsbaum.mdx
@@ -5,7 +5,7 @@ description: "Weihnachten 2025, Spanien"
 draft: true
 tags:
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/weihnachtsbaum/cover.jpg"
 ---
 

--- a/src/data/blog/2025/01/02/sonnenuntergang-aus-dem-flugzeug.mdx
+++ b/src/data/blog/2025/01/02/sonnenuntergang-aus-dem-flugzeug.mdx
@@ -6,7 +6,7 @@ draft: true
 tags:
   - sonnenuntergang
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/sonnenuntergang-aus-dem-flugzeug/cover.jpg"
 ---
 

--- a/src/data/blog/2025/01/14/sonnenaufgang-in-wien.mdx
+++ b/src/data/blog/2025/01/14/sonnenaufgang-in-wien.mdx
@@ -7,7 +7,7 @@ tags:
   - sonnenaufgang
   - landschaft
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/sonnenaufgang-in-wien/cover.jpg"
 ---
 

--- a/src/data/blog/2025/02/01/frost-im-sonnenschein.mdx
+++ b/src/data/blog/2025/02/01/frost-im-sonnenschein.mdx
@@ -5,7 +5,7 @@ description: "Michelberg"
 draft: true
 tags:
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/frost-im-sonnenschein/cover.jpg"
 ---
 

--- a/src/data/blog/2025/03/01/abenddaemmerung-im-heiligenstaedter-park.mdx
+++ b/src/data/blog/2025/03/01/abenddaemmerung-im-heiligenstaedter-park.mdx
@@ -7,7 +7,7 @@ tags:
   - sonnenuntergang
   - landschaft
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/abenddaemmerung-im-heiligenstaedter-park/cover.jpg"
 ---
 

--- a/src/data/blog/2025/03/01/ruhe-in-den-bergen.mdx
+++ b/src/data/blog/2025/03/01/ruhe-in-den-bergen.mdx
@@ -7,7 +7,7 @@ tags:
   - zeichnen
   - landschaft
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/ruhe-in-den-bergen/cover.jpg"
 ---
 

--- a/src/data/blog/2025/03/01/sonnenuntergang-ueber-den-huegeln.mdx
+++ b/src/data/blog/2025/03/01/sonnenuntergang-ueber-den-huegeln.mdx
@@ -8,7 +8,7 @@ tags:
   - sonnenuntergang
   - landschaft
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/sonnenuntergang-ueber-den-huegeln/cover.jpg"
 ---
 

--- a/src/data/blog/2026/04/26/alles-im-blick.mdx
+++ b/src/data/blog/2026/04/26/alles-im-blick.mdx
@@ -6,7 +6,7 @@ tags:
   - tiere
   - Spanien
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "src/assets/blogimages/alles-im-blick/cover.jpg"
 ---
 import Gallery from '@/components/Gallery.astro';

--- a/src/data/blog/2026/04/26/black-and-white.mdx
+++ b/src/data/blog/2026/04/26/black-and-white.mdx
@@ -8,7 +8,7 @@ tags:
   - Spanien
   - schwarz-weiß
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/black-and-white/cover.jpg"
 ---
 

--- a/src/data/blog/2026/04/26/feuertulpen.mdx
+++ b/src/data/blog/2026/04/26/feuertulpen.mdx
@@ -7,7 +7,7 @@ tags:
   - natur
   - Spanien
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/feuertulpen/cover.jpg"
 ---
 

--- a/src/data/blog/2026/04/26/fields-of-gold.mdx
+++ b/src/data/blog/2026/04/26/fields-of-gold.mdx
@@ -8,7 +8,7 @@ tags:
   - Schweden
   - musik
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/fields-of-gold/cover.jpg"
 ---
 

--- a/src/data/blog/2026/04/26/love-shine-a-light.mdx
+++ b/src/data/blog/2026/04/26/love-shine-a-light.mdx
@@ -7,7 +7,7 @@ tags:
   - licht
   - musik
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/love-shine-a-light/cover.jpg"
 ---
 

--- a/src/data/blog/2026/04/26/mediterranischer-himmel.mdx
+++ b/src/data/blog/2026/04/26/mediterranischer-himmel.mdx
@@ -7,7 +7,7 @@ tags:
   - himmel
   - licht
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/mediterranischer-himmel/cover.jpg"
 ---
 

--- a/src/data/blog/2026/04/26/orion.mdx
+++ b/src/data/blog/2026/04/26/orion.mdx
@@ -6,7 +6,7 @@ tags:
   - sterne
   - himmel
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "@/assets/blogimages/orion/orion-ueber-den-bergen.jpg"
 ---
 

--- a/src/data/blog/2026/04/26/riders-on-the-storm.mdx
+++ b/src/data/blog/2026/04/26/riders-on-the-storm.mdx
@@ -7,7 +7,7 @@ tags:
   - Schweden
   - musik
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "src/assets/blogimages/riders-on-the-storm/riders-on-the-storm.jpg"
 ---
 

--- a/src/data/blog/2026/04/26/ring-of-fire.mdx
+++ b/src/data/blog/2026/04/26/ring-of-fire.mdx
@@ -6,7 +6,7 @@ tags:
   - Spanien
   - musik
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "src/assets/blogimages/ring-of-fire/cover.jpg"
 ---
 

--- a/src/data/blog/2026/05/06/birke.mdx
+++ b/src/data/blog/2026/05/06/birke.mdx
@@ -6,7 +6,7 @@ tags:
   - natur
   - licht
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "src/assets/blogimages/birke/cover.jpg"
 ---
 

--- a/src/data/blog/2026/05/06/blaetterregen.mdx
+++ b/src/data/blog/2026/05/06/blaetterregen.mdx
@@ -6,7 +6,7 @@ tags:
   - natur
   - licht
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "src/assets/blogimages/blaetterregen/cover.jpg"
 ---
 

--- a/src/data/blog/2026/05/12/the-dark-side.mdx
+++ b/src/data/blog/2026/05/12/the-dark-side.mdx
@@ -6,7 +6,7 @@ tags:
   - schwarz-weiß
   - wasser
   - fotoblog
-  - fotographie
+  - fotografie
 ogImage: "src/assets/blogimages/the-dark-side/cover.jpg"
 ---
 

--- a/src/pages/tags/[tag]/[...page].astro
+++ b/src/pages/tags/[tag]/[...page].astro
@@ -18,7 +18,7 @@ export async function getStaticPaths({ paginate }: GetStaticPathsOptions) {
 
   return tags.flatMap(({ tag, tagName }) => {
     const tagPosts = getPostsByTag(posts, tag);
-    const isPhotoblog = tag === "fotoblog" || tag === "fotographie";
+    const isPhotoblog = tag === "fotoblog" || tag === "fotografie";
 
     return paginate(tagPosts, {
       params: { tag },
@@ -32,7 +32,7 @@ const params = Astro.params;
 const { tag } = params;
 const { page, tagName } = Astro.props;
 
-const isPhotoblogTag = tag === "fotoblog" || tag === "fotographie";
+const isPhotoblogTag = tag === "fotoblog" || tag === "fotografie";
 ---
 
 <Layout title={`Tag: ${tagName} | ${SITE.title}`}>


### PR DESCRIPTION
## Summary
- Rename the `fotographie` tag to `fotografie` across matching blog posts.
- Keep the renamed `fotografie` tag rendered with the photoblog gallery layout.

## Validation
- `npm run build`